### PR TITLE
upgrade-django-3.2.14

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'cached-property',
-        'django==3.2.13',
+        'django==3.2.14',
         'enum34;python_version<"3.4"',
         'futures;python_version<"3"',
         'requests',


### PR DESCRIPTION
Upgrades django to remove [SQL injection vulnerability](https://github.com/fecgov/fec-eregs/issues/695). 

Connected to PR#  [#695](https://github.com/fecgov/fec-eregs/pull/696) in the e-regs repo.